### PR TITLE
Fixed infinite recursion and segfault bugs

### DIFF
--- a/include/memstack.h
+++ b/include/memstack.h
@@ -7,6 +7,16 @@
 #ifndef MC_MEMSTACK_H
 #define MC_MEMSTACK_H
 
+#include <stdlib.h>
+#include <stdio.h>
+
+// C macro to improve readability when using the library.
+// Example:
+// Before: msfree(NULL);  // Does not explicitly show global is being freed
+// After: msfree(GLOBAL_MEMSTACK);  // Does show global is being freed
+// It isn't necessary to use this however, and using NULL will also work.
+#define GLOBAL_MEMSTACK NULL
+
 // Linked list node.
 // Stores a ptr to the memory allocated and the next element in the linked list.
 // If *next* is NULL then that node is the last node in the linked list.

--- a/src/memstack.c
+++ b/src/memstack.c
@@ -49,9 +49,11 @@ memstack* msnew() {
 // Allocates a new node onto the memstack chain and allocates the space of parameter "size" for the user.
 void* msalloc(memstack* storage, int size) {
     if(storage == GLOBAL_MEMSTACK) {
+        // Ensure global is initialised before allocating
         if (global != NULL) {
             return msalloc(global, size);
         } else {
+            // if not initialised, msalloc() now calls msinit() for the user
             msinit();
             return msalloc(global, size);
         }
@@ -86,11 +88,14 @@ void free_node(memstack_chain_ptr* node){
 // Frees all the nodes stored within the memstack and frees the memstack itself.
 void msfree(memstack* storage) {
     if (storage == GLOBAL_MEMSTACK) {
+        // Ensure global is not NULL before freeing
+        // This is because we dereference global (so we don't want it to be NULL)
         if (global != NULL) {
             free_node(global->first);
             free(global);
         }
     } else {
+        // If it's not NULL we can free it normally
         free_node(storage->first);
         free(storage);
     }


### PR DESCRIPTION
## Segmentation fault bugs & infinite recursion
Most segmentation faults in the library occurred from global being de-referenced when it is (currently) a uninitialised pointer. Multiple times in the library, we do not ensure global is not uninitialised or NULL, this causes segmentation faults to occur when we de-reference global.

Example, in msalloc we check if the user wants to allocate onto the global memstack. If they do, we allocate without checking if global is not uninitialised (if `msinit()` hasn't been called).
```c
void* msalloc(memstack* storage, int size) {
    if(storage == NULL)
        return msalloc(global, size);
```
The solution to this is to default `global` to `NULL`. However, as you can see with the code above, if `global` defaults to `NULL` then `msalloc` will call itself infinitely. To solve this, I added a check to see if the global memstack was null, and if so it would run `msinit()` *and then* call itself. This would initialise `global` to no longer be `NULL` fixing the recursion.

Now is the final issue, if `global` is pre-defined as `NULL`, and the user calls `msalloc` or `msfree` before `msinit` the functions will attempt to de-reference the global memstack. De-referencing a NULL pointer will cause undefined behaviour, usually segfault. This is why my code contains additional checks to ensure `global` is not `NULL` before running the function's code.

### Smaller changes
I've added a macro to `include/memstack.h`, `GLOBAL_MEMSTACK` is defined as `NULL`.
This macro serves to make calling `msalloc` and `msfree` more readable when modifying the global stack.
*NOTE: this does not break existing code as NULL can still be used instead of GLOBAL_MEMSTACK*

Example of editing global stack currently.
```c
#include <memstack.h>

int main() {
    msinit()
    int* a = msalloc(NULL, sizeof(int));
    msfree(NULL);  // It's not obvious we are using the global memstack
}
```

Example of editing global stack now.
```c
#include <memstack.h>

int main() {
    msinit()
    int* a = msalloc(GLOBAL_MEMSTACK, sizeof(int));
    msfree(GLOBAL_MEMSTACK);  // It's now very obvious we are
}
```
