### PR TITLE
New functionality, bug fixes, and enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ int main(){
 }
 ```
 
-## Legcacy example
+## Legacy example
 ```c
 // example.c
 // Compile with "gcc example.c -lmemstack -o example" and run with "./example"

--- a/include/memstack.h
+++ b/include/memstack.h
@@ -41,4 +41,5 @@ extern void msclear(memstack* storage);  // Frees allocations but doesn't delete
 extern void mspush(memstack* storage, void* ptr);  // Adds new memory into the memstack even if it hasn't been allocated with msalloc()
 extern void* mspop(memstack* storage);  // Removes the last node from the memstack and returns the user allocated memory
 extern void msprint(memstack* storage);  // Displays all the nodes in the memstack for debugging uses
+extern void msrollback(memstack* storage, int rollback_count, bool destructive);  // Removes a number of nodes from a memstack
 #endif

--- a/include/memstack.h
+++ b/include/memstack.h
@@ -9,6 +9,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 // C macro to improve readability when using the library.
 // Example:

--- a/include/memstack.h
+++ b/include/memstack.h
@@ -32,6 +32,7 @@ typedef struct memstack_chain_ptr_t{
 typedef struct memstack_t {
     memstack_chain_ptr* last;  // Stores last element
     memstack_chain_ptr* first;  // Stores first element
+    int length;
 } memstack;
 
 extern void msinit(); // Initializes a global memstack, that can be accessed by passing in "NULL" as storage in the other funcs

--- a/include/memstack.h
+++ b/include/memstack.h
@@ -38,6 +38,7 @@ extern memstack* msnew();  // Creates a new memstack
 extern void* msalloc(memstack* storage, int size);  // Allocate onto memstack and return pointer
 extern void msfree(memstack* storage);  // Free all of memstack
 extern void msclear(memstack* storage);  // Frees allocations but doesn't delete the memstack
-
-
+extern void mspush(memstack* storage, void* ptr);  // Adds new memory into the memstack even if it hasn't been allocated with msalloc()
+extern void* mspop(memstack* storage);  // Removes the last node from the memstack and returns the user allocated memory
+extern void msprint(memstack* storage);  // Displays all the nodes in the memstack for debugging uses
 #endif

--- a/include/memstack.h
+++ b/include/memstack.h
@@ -9,7 +9,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <stdbool.h>
 
 // C macro to improve readability when using the library.
 // Example:
@@ -43,5 +42,5 @@ extern void msclear(memstack* storage);  // Frees allocations but doesn't delete
 extern void mspush(memstack* storage, void* ptr);  // Adds new memory into the memstack even if it hasn't been allocated with msalloc()
 extern void* mspop(memstack* storage);  // Removes the last node from the memstack and returns the user allocated memory
 extern void msprint(memstack* storage);  // Displays all the nodes in the memstack for debugging uses
-extern void msrollback(memstack* storage, int rollback_count, bool destructive);  // Removes a number of nodes from a memstack
+extern void msrollback(memstack* storage, int rollback_count, int destructive);  // Removes a number of nodes from a memstack
 #endif

--- a/include/memstack.h
+++ b/include/memstack.h
@@ -23,6 +23,7 @@
 typedef struct memstack_chain_ptr_t{
     void* ptr;  // Pointer to the memory allocated
     struct memstack_chain_ptr_t* next;  // Pointer to next node
+    struct memstack_chain_ptr_t* previous;  // Pointer to previous node
 } memstack_chain_ptr;
 
 // Memstack structure.

--- a/include/memstack.h
+++ b/include/memstack.h
@@ -36,6 +36,7 @@ extern void msinit(); // Initializes a global memstack, that can be accessed by 
 extern memstack* msnew();  // Creates a new memstack
 extern void* msalloc(memstack* storage, int size);  // Allocate onto memstack and return pointer
 extern void msfree(memstack* storage);  // Free all of memstack
+extern void msclear(memstack* storage);  // Frees allocations but doesn't delete the memstack
 
 
 #endif

--- a/src/memstack.c
+++ b/src/memstack.c
@@ -33,12 +33,7 @@ void msinit(){
 memstack* msnew() {
     // Allocate new memstack and the first memstack chain pointer.
     memstack* ms = (memstack*)malloc(sizeof(memstack));
-    ms->first = (memstack_chain_ptr*)malloc(sizeof(memstack_chain_ptr));
-
-    // We just set everything to NULL for now.
-    ms->first->ptr = NULL;
-    ms->first->next = NULL;
-    ms->first->previous = NULL;
+    ms->first = NULL;  // There are no chain pointers yet.
 
     // Very important! We dereference ms->last in msalloc so
     // removing this line causes undefined behaviour (probably segfault).
@@ -65,9 +60,16 @@ void* msalloc(memstack* storage, int size) {
     new_node->previous = storage->last;  // Set the previous node as the current last node
     new_node->next = NULL;  // This will be the last element so "next" is NULL.
 
-    // Make our new node the last node
-    storage->last->next = new_node;
-    storage->last = new_node;
+    // Check if there is a first node
+    if (storage->first == NULL) {
+        // If not, the node we just created will become the first node.
+        storage->first = new_node;
+        storage->last = storage->first;
+    } else {
+        // If there is we just create a new last node
+        storage->last->next = new_node;
+        storage->last = new_node;
+    }
 
     return new_node->ptr;  // Return pointer to memory user wanted to be allocated.
 }
@@ -75,6 +77,10 @@ void* msalloc(memstack* storage, int size) {
 // Recursively frees all the nodes.
 // Totally a re-skin of free_index because I like this function but "node" sounded better to me.
 void free_node(memstack_chain_ptr* node){
+
+    if (node == NULL) {
+        return;
+    }
 
     // We check if the node contains one of the user's allocations and free it.
     if(node->ptr != NULL)

--- a/src/memstack.c
+++ b/src/memstack.c
@@ -251,7 +251,7 @@ void msprint(memstack* storage) {
 // The boolean parameter "destructive" details whether the user allocated memory (void* ptr) is freed or not.
 // If destructive is true, then everything is freed, even the user allocated memory,
 // otherwise, if destructive is false, the user allocate memory is not removed (DANGEROUS).
-void msrollback(memstack* storage, int rollback_count, bool destructive) {
+void msrollback(memstack* storage, int rollback_count, int destructive) {
 
     if (storage == GLOBAL_MEMSTACK) {
         if (global != NULL) {

--- a/src/memstack.c
+++ b/src/memstack.c
@@ -253,14 +253,23 @@ void msprint(memstack* storage) {
 // otherwise, if destructive is false, the user allocate memory is not removed (DANGEROUS).
 void msrollback(memstack* storage, int rollback_count, bool destructive) {
 
-    // Destroys "rollback_count" nodes
-    while (rollback_count > 0) {
-        // mspop() will handle freeing the latest node for us
-        void* ptr = mspop(storage);
-        if (destructive) {
-            free(ptr);  // Free user allocated memory if rollback is destructive
+    if (storage == GLOBAL_MEMSTACK) {
+        if (global != NULL) {
+            msrollback(global, rollback_count, destructive);
+        } else {
+            return;
         }
-        --rollback_count;
-        --storage->length;
+    } else {
+        // Destroys "rollback_count" nodes
+        while (rollback_count > 0) {
+            // mspop() will handle freeing the latest node for us
+            void* ptr = mspop(storage);
+            if (destructive == 1) {
+                free(ptr);  // Free user allocated memory if rollback is destructive
+            }
+            --rollback_count;
+            --storage->length;
+        }
     }
+
 }

--- a/src/memstack.c
+++ b/src/memstack.c
@@ -38,6 +38,7 @@ memstack* msnew() {
     // We just set everything to NULL for now.
     ms->first->ptr = NULL;
     ms->first->next = NULL;
+    ms->first->previous = NULL;
 
     // Very important! We dereference ms->last in msalloc so
     // removing this line causes undefined behaviour (probably segfault).
@@ -61,6 +62,7 @@ void* msalloc(memstack* storage, int size) {
     // Create new node to add to the linked list.
     memstack_chain_ptr* new_node = (memstack_chain_ptr*)malloc(sizeof(memstack_chain_ptr));
     new_node->ptr = malloc(size);  // Allocate space user requested.
+    new_node->previous = storage->last;  // Set the previous node as the current last node
     new_node->next = NULL;  // This will be the last element so "next" is NULL.
 
     // Make our new node the last node
@@ -121,6 +123,7 @@ void msclear(memstack* storage) {
         // Create a new memstack_chain_ptr* chain
         storage->first = (memstack_chain_ptr*)malloc(sizeof(memstack_chain_ptr));
         storage->first->next = NULL;
+        storage->first->previous = NULL;
         storage->first->ptr = NULL;
 
         // Set up last pointer for future allocations

--- a/src/memstack.c
+++ b/src/memstack.c
@@ -100,3 +100,31 @@ void msfree(memstack* storage) {
         free(storage);
     }
 }
+
+// Frees all nodes stored within the memstack but does not free the memstack itself.
+void msclear(memstack* storage) {
+
+    // Check if we're clearing global or not
+    if (storage == GLOBAL_MEMSTACK) {
+
+        // Ensure global is not NULL
+        if (global != NULL) {
+            msclear(global);  // Since global isn't NULL "storage == GLOBAL_MEMSTACK" will be false...
+        } else {
+            msinit();  // initialise global if not NULL.
+            // We don't have to clear since msinit() generates an empty global anyway.
+        }
+    } else {
+        // Free the memstack_chain_ptr* chain
+        free_node(storage->first);
+
+        // Create a new memstack_chain_ptr* chain
+        storage->first = (memstack_chain_ptr*)malloc(sizeof(memstack_chain_ptr));
+        storage->first->next = NULL;
+        storage->first->ptr = NULL;
+
+        // Set up last pointer for future allocations
+        storage->last = storage->first;
+    }
+
+}


### PR DESCRIPTION
## New functionality

### Doubly linked list > Singly linked list
A singly linked list is a linked list where nodes are connected by pointer to the next node. This is a very simple, low overhead data structure, but it has it's disadvantages. In order to delete a node from the linked list, we must loop the entire list to find the previous node so the previous node can be linked to the node after the node we want to delete (e.g. Keeping the list linked together).
```
┌──────┐    ┌──────┐    ┌──────┐
│      │    │      │    │      │
│ Node ├────► Node ├────► Node │ 
│      │    │      │    │      │
└──────┘    └──────┘    └──────┘
```
A doubly linked list is a linked list where nodes are connected by pointers both to the next node and the previous node. The advantage of this over a singly linked list is that to delete a node, we already have both the previous, and next node. This means delete nodes from a doubly linked list is significantly faster than a singly linked list.
```
┌──────┐    ┌──────┐    ┌──────┐
│      ├────►      ├────►      │
│ Node │    │ Node │    │ Node │
│      ◄────┤      ◄────┤      │
└──────┘    └──────┘    └──────┘
```
Currently, the library can allocate onto the memstack, and then free the entire memstack at once. This is an incredibly useful functionality, but I believe the library would benefit from having the ability to do the following:

1. De-allocate the memstack *without* deleting the memstack itself like `msfree` does.
2. De-allocate a set number of nodes *with* and *without* deleting the user allocated memory.
3. Add new nodes to a memstack without having to allocate through the memstack library
4. Remove a node from the memstack and return the user allocated memory

Each section below details a function that can complete each functionality list above.

### msclear(memstack*)
`msclear` is used to clear a memstack without deleting the memstack itself. This is useful if further allocations are going to be made, but previous allocations must be freed. In this case, using `msfree` would require another `memstack*` to be create which is inefficient and annoying.

```c
memstack* ms = msnew();  // Create a new memstack
int* a = msalloc(ms, sizeof(int));  // Allocate onto the memstack
int* b = msalloc(ms, sizeof(int));
int* c = msalloc(ms, sizeof(int));
// ...
// Now we want to get rid of the allocations...
// But we want to make more allocations within the same scope!

// Using msfree would require us to call msnew() again which is annoying
msclear(ms);  // Instead, we "clear" the memstack's chain, but the memstack still exists!
int* x = msalloc(ms, sizeof(int));  // We can continue allocating to the memstack

// ...
// We finally free the memstack now we are done!
msfree(ms);
```

### mspop(memstack*)
`mspop` allows the user to free the last `memstack_chain_ptr*` node of a `memstack*` and get a return value of the `memstack_chain_ptr*`'s `void* ptr`. This essentially "removes" the allocation from the memstack thereby, removing the pointer from being freed by `msfree` or `msclear` later on.

```c
memstack* ms = msnew();  // Create a new memstack
int* a = msalloc(ms, sizeof(int));  // Allocate onto the memstack
int* b = msalloc(ms, sizeof(int));
int* c = msalloc(ms, sizeof(int));
// ...
// Now we want to free "a" and "b", but not "c".
// We can do this by using `mspop`.
c = mspop(ms);

msfree(ms); // Now we can free the memstack, but keep c for further use...

// ...
// The user is now in charge of "c", they must free it themselves.
free(c);
```
It's important to note, `mspop` will always remove the last element in the `memstack_chain_ptr*` chain. So, in order to "pop" a memstack node, it must have been the last one allocated.

### mspush(memstack*, void*)
`mspush` allows allocations to be added to the memstack *without* the memory having been allocated by `msalloc`. This would allow users to manage allocations themselves, and then add those allocation to the `memstack*` if they wish.

This could also be used in scenarios when other library allocate memory for the user, and the user wants it all to be freed at once.

```c
memstack* ms = msnew();  // Create a new memstack

int* a = malloc(sizeof(int));  // Allocating memory ourselves
int* b = give_me_memory();  // Allocating memory from another library's function

// ...
// The user wants these to be freed all at once, but the memory has already 
// been allocated so they cannot use msalloc()!

mspush(ms, a);  // We can add them anyway!
mspush(ms, b);

msfree(ms);  // This will free "a" and "b" for us!
```

### msrollback(memstack*, int, bool)
`msrollback` allows for many `memstack_chain_ptr*` nodes to be freed at once, but not necessarily all nodes, or memory will be freed! The user may specify the number of nodes they wish to be deleted, and whether the user memory will be deleted along with the node or not!

This would be extremely useful for deleting many nodes from the `memstack*` without deleting the memory the `memstack_chain_ptr*` was holding for the user.
```c
memstack* ms = msnew();  // Create a new memstack

int* a = msalloc(sizeof(int));  // Allocate onto the memstack
int* b = msalloc(sizeof(int));
int* c = msalloc(sizeof(int));
int* d = msalloc(sizeof(int));

// ... 
// I no longer want the memstack to manage "d" for me
// I want to free "b" and "c", without freeing "a" yet

msrollback(ms, 1, false);  // Removing the last element, without freeing the user's pointer
msrollback(ms, 2, true);  // Removing 2 elements starting at the last, free everything

*d = 100;  // "d" can still be accessed and managed by myself
*a = 100;  // "a" is managed by the memstack still, "b" and "c" are freed

msfree(a);  // "a" is gone!
free(d);  // I've freed "d" myself
```

### msprint(memstack*)
`msprint` has nothing to do with managing memory instead, it is for contributers, and users of the library to debug their programs better. `msprint` will display the given `memstack` in the console which can help understand what's on the memstack.

It's usefulness can be shown through an example:
```c
#include "memstack.h"

int main() {
    msinit();  // initialise global
    int* a = msalloc(GLOBAL_MEMSTACK, sizeof(int));  // Create allocations
    int* b = msalloc(GLOBAL_MEMSTACK, sizeof(int));
    int* c = msalloc(GLOBAL_MEMSTACK, sizeof(int));

    // Print the contents of global
    msprint(GLOBAL_MEMSTACK);

    // Modify global by freeing the last element
    free(mspop(GLOBAL_MEMSTACK));

    // print the contents of global again
    msprint(GLOBAL_MEMSTACK);

    msfree(GLOBAL_MEMSTACK); 
    return 0;
}
```
The output from this code is:
```sh
Printing memstack: 
 [-1] (nil) <--previous-- [0] Current: 0x562cff95c6d0 --next--> [1] 0x562cff95c710
 [0] 0x562cff95c6d0 <--previous-- [1] Current: 0x562cff95c710 --next--> [2] 0x562cff95c750
 [1] 0x562cff95c710 <--previous-- [2] Current: 0x562cff95c750 --next--> [3] (nil)
 [INFO] Node count: 3
 [INFO] Nodes are linked to both the next, and previous node
Printing memstack: 
 [-1] (nil) <--previous-- [0] Current: 0x562cff95c6d0 --next--> [1] 0x562cff95c710
 [0] 0x562cff95c6d0 <--previous-- [1] Current: 0x562cff95c710 --next--> [2] (nil)
 [INFO] Node count: 2
 [INFO] Nodes are linked to both the next, and previous node
```

## Bug fixes

### Fixed dead memstack node allocated every msnew() call
`msnew()` creates a "first" node but that node is never used because `msalloc` always adds a new `memstack_chain_ptr*` node to the `memstack*`. This issue was found during the implementation of `mspop` and fixed with help from `msprint`. 

## Enhancements
- Fixed "Legcacy" typo in README
- Added more code comments (idk how.. There are already so many lmao)
- Added a length property to the memstack struct