### PR TITLE
Minor fix to msrollback to include stdlib.h

### DIFF
--- a/examples/msrollback.c
+++ b/examples/msrollback.c
@@ -1,5 +1,6 @@
 #include <memstack.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 int main(void) {
     printf("Running example \"msrollback\"!\n");


### PR DESCRIPTION
This should make it ever so slightly more standard compliant + remove the warnings