### PR TITLE
Added destructor function to clean up the global memstack

### DIFF
--- a/include/memstack.h
+++ b/include/memstack.h
@@ -19,6 +19,17 @@
 #define MSTRUE (1==1)
 #define MSFALSE (!MSTRUE)
 
+// Certain compilers support destructors, which are pieces of code invoked at the end of a programs lifetime.
+// Now, because this doesn't apply to all compilers, we have the MSCLEANUP definition.
+// This is defined for GCC, clang, and ICC, since those all support destructors.
+// The intended use-case is just so that you can know whether or not the global stack will be automatically
+// cleaned on your system, provided you compile memstack and the program with THE SAME COMPILER.
+#if defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)
+#define MSCLEANUP
+#else
+#warning Memstack global cleanup is not available for your compiler, make sure you clean it up yourself
+#endif
+
 // Linked list node.
 // Stores a ptr to the memory allocated and the next element in the linked list.
 // If *next* is NULL then that node is the last node in the linked list.

--- a/src/memstack.c
+++ b/src/memstack.c
@@ -331,8 +331,12 @@ void msdealloc(memstack* storage, void* memory) {
 
 }
 
+#ifdef MSCLEANUP
+
 __attribute__((destructor)) 
 static void msexit() {
 	msfree(GLOBAL_MEMSTACK);
 }
+
+#endif
 

--- a/src/memstack.c
+++ b/src/memstack.c
@@ -176,7 +176,7 @@ void mspush(memstack* storage, void* ptr) {
         // TODO: Check if this needs to be done elsewhere
         if(storage->first != NULL) {
         	storage->last->next = new_node;
-		      new_node->previous = storage->last;
+		new_node->previous = storage->last;
         	storage->last = new_node;
 
         } else {

--- a/src/memstack.c
+++ b/src/memstack.c
@@ -176,6 +176,7 @@ void mspush(memstack* storage, void* ptr) {
         // TODO: Check if this needs to be done elsewhere
         if(storage->first != NULL) {
         	storage->last->next = new_node;
+		new_node->previous = storage->last;
         	storage->last = new_node;
         } else {
         	storage->first = new_node;
@@ -329,3 +330,9 @@ void msdealloc(memstack* storage, void* memory) {
   free(memory);
 
 }
+
+__attribute__((destructor)) 
+static void msexit() {
+	msfree(GLOBAL_MEMSTACK);
+}
+


### PR DESCRIPTION
As requested in #17, the code should now clean up the global memstack before exit.

Currently this only compiles for GCC, so I think some research is due.